### PR TITLE
Create a connection to master when the slave is not specified

### DIFF
--- a/spec/slavery_spec.rb
+++ b/spec/slavery_spec.rb
@@ -52,4 +52,16 @@ describe Slavery do
     Slavery.stub(:disabled).and_return(true)
     Slavery.on_slave { User.slaveryable?.should == false }
   end
+
+  it 'connects to master if slave configuration not specified' do
+    begin
+      User.clear_connection_holder
+      old_config = ActiveRecord::Base.configurations
+      ActiveRecord::Base.configurations['test_slave'] = nil
+
+      Slavery.on_slave { User.count }.should == 2
+    ensure
+      ActiveRecord::Base.configurations = old_config
+    end
+  end
 end


### PR DESCRIPTION
Hi there:

Just tried out the gem and it works great in our app.  However, in our company we have many environments (QA, production, etc) that we deploy to and not all of the environments either have a slave or need to use the slave.  I made some changes so that if a slave is not specified in the database.yml, it will create a connection against master instead.

Can you take a look and see if it is acceptable to be included in the gem?  If you have any suggestions for improvement, please let me know.

Thanks,
Jason
