### PR TITLE
Allow to use SLAVE_DATABASE_URL as connection URL for slave database.

### DIFF
--- a/lib/slavery.rb
+++ b/lib/slavery.rb
@@ -94,7 +94,7 @@ module Slavery
 
         spec = [Slavery.spec_key, Slavery.env].find do |spec_key|
           ActiveRecord::Base.configurations[spec_key]
-        end or raise Error.new("#{Slavery.spec_key} or #{Slavery.env} must exist!")
+        end || ENV['SLAVE_DATABASE_URL'] or raise Error.new("#{Slavery.spec_key} or #{Slavery.env} must exist!")
 
         establish_connection spec
       }

--- a/spec/slavery_spec.rb
+++ b/spec/slavery_spec.rb
@@ -60,7 +60,7 @@ describe Slavery do
     Slavery.spec_key = lambda{
       "kewl_slave"
     }
-    Slavery.spec_key.should eq "kewl_slave"    
+    Slavery.spec_key.should eq "kewl_slave"
 
     Slavery.spec_key = lambda{
       "#{Slavery.env}_slave"
@@ -103,6 +103,18 @@ describe Slavery do
       ActiveRecord::Base.configurations[Slavery.spec_key] = nil
 
       expect { Slavery.on_slave { User.count } }.to raise_error(Slavery::Error)
+    end
+
+    it 'works with SLAVE_DATABASE_URL environment variable' do
+      Slavery.spec_key = nil
+      Slavery.env = nil
+
+      ENV['SLAVE_DATABASE_URL'] = 'sqlite3:///?database=test_slave_db'
+
+      Slavery.on_slave  { User.count }.should == 1
+
+      ENV['SLAVE_DATABASE_URL'] = nil
+      Slavery.env = 'test'
     end
   end
 end


### PR DESCRIPTION
It's hard to set up slave connection when DATABASE_URL environment URL is used instead of database.yml file.

I suggest to allow to use SLAVE_DATABASE_URL for slave connection.

In this case gem could be easier used within Foreman(https://github.com/ddollar/foreman) or DotEnv(https://github.com/bkeepers/dotenv)
