### PR TITLE
Update Readme include how to run tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ ActiveRecord::Base.establish_connection(:development)
 ```
 
 ## Running tests
+
 ```shell
 export RAILS_ENV=test
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,13 @@ ActiveRecord::Base.configurations = {
 ActiveRecord::Base.establish_connection(:development)
 ```
 
+## Running tests
+```shell
+export RAILS_ENV=test
+
+bundle exec rspec spec
+```
+
 ## Changelog
 
 * v4.0.0: Rename gem from Slavery to Standby


### PR DESCRIPTION
It was not obvious at first glance that RAILS_ENV needed to be set to `test` in order to get test to work.