### PR TITLE
Use ActiveRecord::Base.connected? to avoid creating unneeded connections

### DIFF
--- a/lib/standby/base.rb
+++ b/lib/standby/base.rb
@@ -25,6 +25,7 @@ module Standby
     end
 
     def inside_transaction?
+      return false unless ActiveRecord::Base.connected?
       open_transactions = run_on(:primary) { ActiveRecord::Base.connection.open_transactions }
       open_transactions > Standby::Transaction.base_depth
     end


### PR DESCRIPTION
This PR makes use of `ActiveRecord::Base.connected?` in the `inside_transaction` method to avoid the needless creation of extra connections to the primary configured DB. 

<img width="1168" alt="image" src="https://user-images.githubusercontent.com/673382/62506272-fb12c200-b7cd-11e9-9951-50231adb24f8.png">

<img width="1633" alt="image" src="https://user-images.githubusercontent.com/673382/62506257-e59d9800-b7cd-11e9-90fa-e90a4abfab43.png">
