### PR TITLE
fix: define connection holder more thread-safe

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,9 +6,10 @@ ENV['RACK_ENV'] = 'test'
 require 'standby'
 
 ActiveRecord::Base.configurations = {
-  'test'            =>  { 'adapter' => 'sqlite3', 'database' => 'test_db' },
-  'test_standby'      =>  { 'adapter' => 'sqlite3', 'database' => 'test_standby_one' },
-  'test_standby_two'  =>  { 'adapter' => 'sqlite3', 'database' => 'test_standby_two'},
+  'test'            =>  { 'adapter' => 'sqlite3', 'database' => 'test_db', 'pool' => 30 },
+  'test_standby'      =>  { 'adapter' => 'sqlite3', 'database' => 'test_standby_one', 'pool' => 30 },
+  'test_standby_two'  =>  { 'adapter' => 'sqlite3', 'database' => 'test_standby_two', 'pool' => 30 },
+  'test_standby_three' => { 'adapter' => 'postgresql', 'database' => 'test_standby_three', 'pool' => 10, 'checkout_timeout' => 1 },
   'test_standby_url'  =>  'postgres://root:@localhost:5432/test_standby'
 }
 

--- a/standby.gemspec
+++ b/standby.gemspec
@@ -20,5 +20,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'activerecord', '>= 3.0.0'
 
   gem.add_development_dependency 'rspec'
-  gem.add_development_dependency 'sqlite3'
+  gem.add_development_dependency 'sqlite3', '~> 1.3', '< 1.4'
+  gem.add_development_dependency 'pg'
 end


### PR DESCRIPTION
AR's establish_connection is not thread-safe. If standby connection is not established
beforehand concurrent threads will raise something like:
```
ActiveRecord::ConnectionNotEstablished: No connection pool with id SlaverySlaveConnectionHolder found.
```