### PR TITLE
MTR-280 Fix deprecated [] for rails 6.2 on ActiveRecord::Base.configu…

### DIFF
--- a/gemfiles/rails6.1.gemfile
+++ b/gemfiles/rails6.1.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'activerecord', '~> 6.1'
+
+gemspec name: 'standby', path: '../'

--- a/lib/standby/connection_holder.rb
+++ b/lib/standby/connection_holder.rb
@@ -5,7 +5,8 @@ module Standby
     class << self
       # for delayed activation
       def activate(target)
-        spec = ActiveRecord::Base.configurations["#{ActiveRecord::ConnectionHandling::RAILS_ENV.call}_#{target}"]
+        env_name = "#{ActiveRecord::ConnectionHandling::RAILS_ENV.call}_#{target}"
+        spec = ActiveRecord::Base.configurations.configs_for(env_name: env_name).first&.configuration_hash
         raise Error.new("Standby target '#{target}' is invalid!") if spec.nil?
         establish_connection spec
       end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -20,13 +20,21 @@ describe 'configuration' do
   end
 
   it 'raises error if standby configuration not specified' do
-    ActiveRecord::Base.configurations['test_standby'] = nil
+    ActiveRecord::Base.configurations = {
+      'test' => { 'adapter' => 'sqlite3', 'database' => 'test_db' },
+      'test_standby_two' => { 'adapter' => 'sqlite3', 'database' => 'test_standby_two' },
+      'test_standby_url' => 'postgres://root:@localhost:5432/test_standby'
+    }
 
     expect { Standby.on_standby { User.count } }.to raise_error(Standby::Error)
   end
 
   it 'connects to primary if standby configuration is disabled' do
-    ActiveRecord::Base.configurations['test_standby'] = nil
+    ActiveRecord::Base.configurations = {
+      'test' => { 'adapter' => 'sqlite3', 'database' => 'test_db' },
+      'test_standby_two' => { 'adapter' => 'sqlite3', 'database' => 'test_standby_two' },
+      'test_standby_url' => 'postgres://root:@localhost:5432/test_standby'
+    }
     Standby.disabled = true
 
     expect(Standby.on_standby { User.count }).to be 2


### PR DESCRIPTION
Fix the deprecation for rails 6.2:
```
DEPRECATION WARNING: [] is deprecated and will be removed from Rails 6.2 (Use configs_for) (called from activate at /home/mathieu/facilecomm/standby/lib/standby/connection_holder.rb:8)
```