### PR TITLE
For Rails 7.1 or above, use the named bold param

### DIFF
--- a/lib/standby/active_record/log_subscriber.rb
+++ b/lib/standby/active_record/log_subscriber.rb
@@ -4,9 +4,16 @@ module ActiveRecord
     alias_method :debug_without_standby, :debug
 
     def debug(msg)
-      db = Standby.disabled ? "" : color("[#{Thread.current[:_standby] || "primary"}]", ActiveSupport::LogSubscriber::GREEN, true)
+      db = Standby.disabled ? "" : log_header
       debug_without_standby(db + msg)
     end
 
+    def log_header
+      if "#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}".to_f >= 7.1
+        color("[#{Thread.current[:_standby] || "primary"}]", ActiveSupport::LogSubscriber::GREEN, bold: true)
+      else
+        color("[#{Thread.current[:_standby] || "primary"}]", ActiveSupport::LogSubscriber::GREEN, true)
+      end
+    end
   end
 end


### PR DESCRIPTION
When upgrading to Rails 7.1 we're getting the following deprecation warning:

```
DEPRECATION WARNING: Bolding log text with a positional boolean is deprecated and will be removed in Rails 7.2. Use an option hash instead (eg. `color("my text", :red, bold: true)`). (called from debug at .../bundler/gems/standby-6fbc05940118/lib/standby/active_record/log_subscriber.rb:7)
```

This checks the Rails major/minor combo to use the named bold param for the log colour